### PR TITLE
Explicitly ignore config.yml and use a template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ gradle-app.setting
 .project
 .settings
 .vscode
+
+# Sensitive files
+/src/main/resources/config.yml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Embarker
+
+## Getting set up
+
+1. Install MySQL and set up a database
+2. Copy src/main/resources/config.template.yml to config.yml in the same directory. Fill in `url`, `username`, and `password` with your database credentials.

--- a/src/main/resources/config.template.yml
+++ b/src/main/resources/config.template.yml
@@ -1,3 +1,5 @@
+# Rename this to config.yml and fill with your actual DB credentials.
+# Do NOT check config.yml into Git.
 db:
   driver: "com.mysql.jdbc.Driver"
   url: "jdbc:mysql://localhost/database_name"


### PR DESCRIPTION
Move the template to `config.template.yml` and ignore the actual one. This way we don't need to manually exclude it from commits.

This PR also adds a stub README file which includes instructions on setting up this config file.